### PR TITLE
Development

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -234,13 +234,13 @@ files = [
 
 [[package]]
 name = "dynaconf"
-version = "3.2.4"
+version = "3.2.5"
 description = "The dynamic configurator for your Python Project"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "dynaconf-3.2.4-py2.py3-none-any.whl", hash = "sha256:858f9806fab2409c4f5442614c2605d4c4071d5e5153b0e7f24a225f27465aed"},
-    {file = "dynaconf-3.2.4.tar.gz", hash = "sha256:2e6adebaa587f4df9241a16a4bec3fda521154d26b15f3258fde753a592831b6"},
+    {file = "dynaconf-3.2.5-py2.py3-none-any.whl", hash = "sha256:12202fc26546851c05d4194c80bee00197e7c2febcb026e502b0863be9cbbdd8"},
+    {file = "dynaconf-3.2.5.tar.gz", hash = "sha256:42c8d936b32332c4b84e4d4df6dd1626b6ef59c5a94eb60c10cd3c59d6b882f2"},
 ]
 
 [package.extras]
@@ -248,7 +248,7 @@ all = ["configobj", "hvac", "redis", "ruamel.yaml"]
 configobj = ["configobj"]
 ini = ["configobj"]
 redis = ["redis"]
-test = ["configobj", "django", "flake8", "flake8-debugger", "flake8-print", "flake8-todo", "flask (>=0.12)", "hvac (>=1.1.0)", "pep8-naming", "pytest", "pytest-cov", "pytest-mock", "pytest-xdist", "python-dotenv", "radon", "redis", "toml"]
+test = ["configobj", "django", "flask (>=0.12)", "hvac (>=1.1.0)", "pytest", "pytest-cov", "pytest-mock", "pytest-xdist", "python-dotenv", "radon", "redis", "toml"]
 toml = ["toml"]
 vault = ["hvac"]
 yaml = ["ruamel.yaml"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.poetry]
 name = "metadata-refiner"
-version = "1.3.3"
+version = "1.3.4"
 description = "A service that refines metadata."
-authors = ["Thomas van Erven"]
+authors = ["Fjodor van Rijsselberg"]
 
 [tool.poetry.dependencies]
 python = "^3.9.14"

--- a/src/refiners/datastation_refiner.py
+++ b/src/refiners/datastation_refiner.py
@@ -4,9 +4,11 @@ from refiners.dataverse_nl_refiner import format_license
 def refine_datastation_metadata(metadata: dict) -> dict:
 
     if 'license' in metadata['datasetVersion'] and metadata['datasetVersion'][
-        'license'] != 'NONE':
+        'license'] != 'NONE' and metadata['datasetVersion']['license']:
         metadata['datasetVersion']['license'] = format_license(
             metadata['datasetVersion']['license']
         )
+    elif 'license' in metadata['datasetVersion']:
+        del metadata['datasetVersion']['license']
 
     return metadata

--- a/src/tests/test_dataverse_nl_refiner.py
+++ b/src/tests/test_dataverse_nl_refiner.py
@@ -1,6 +1,39 @@
+from refiners.datastation_refiner import refine_datastation_metadata
 from refiners.dataverse_nl_refiner import refine_dataverse_nl_metadata, \
     retrieve_license_name, format_license, refine_field_primitive_to_multiple
 from utils import add_contact_email
+
+
+def test_license_present_but_none():
+    metadata = {
+        'datasetVersion': {
+            'license': 'NONE'
+        }
+    }
+    expected_result = {
+        'datasetVersion': {}
+    }
+    assert refine_datastation_metadata(metadata) == expected_result
+
+def test_license_not_present():
+    metadata = {
+        'datasetVersion': {}
+    }
+    expected_result = {
+        'datasetVersion': {}
+    }
+    assert refine_datastation_metadata(metadata) == expected_result
+
+def test_license_present_but_empty():
+    metadata = {
+        'datasetVersion': {
+            'license': ''
+        }
+    }
+    expected_result = {
+        'datasetVersion': {}
+    }
+    assert refine_datastation_metadata(metadata) == expected_result
 
 
 def test_format_license():


### PR DESCRIPTION
## Description
Updated license formatting for datastation refiner. It now deletes empty or invalid licenses. This is done to prevent errors on ingest because of ill-formatted or empty license fields.

